### PR TITLE
[150] Enable TLS by default using a self-signed certificate.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN mvn package -f /home/app/pom.xml
 #
 # Package stage
 #
-FROM amazoncorretto:17.0.13-alpine3.18
+FROM amazoncorretto:17.0.14-alpine3.18
 
 # for regular linux 
 # RUN useradd --user-group --system --create-home --no-log-init app
@@ -25,7 +25,7 @@ RUN adduser --system app
 RUN mkdir -p /app
 RUN chown app /app
 
-COPY --from=build /home/app/target/oag-exec.jar /home/app/*.yaml /home/app/*.txt /app/
+COPY --from=build /home/app/target/oag-exec.jar /home/app/*.yaml /home/app/*.txt /home/app/*.pkcs12 /app/
 RUN mv /app/*.jar /app/oag.jar
 
 USER app

--- a/oag/.gitignore
+++ b/oag/.gitignore
@@ -35,3 +35,4 @@ build/
 
 ### VS Code ###
 .vscode/
+/keystore.pkcs12

--- a/oag/pom.xml
+++ b/oag/pom.xml
@@ -313,7 +313,7 @@
                         <argument>-validity</argument>
                         <argument>720</argument>
                         <argument>-dname</argument>
-                        <argument>"cn=demo, ou=oag, o=owasp, c=com"</argument>
+                        <argument>cn=demo, ou=oag, o=owasp, c=com</argument>
                     </arguments>
                 </configuration>
             </plugin>

--- a/oag/pom.xml
+++ b/oag/pom.xml
@@ -316,7 +316,7 @@
                 <version>3.5.0</version>
                 <executions>
                     <execution>
-                        <phase>generate-sources</phase>
+                        <phase>generate-resources</phase>
                         <goals>
                             <goal>exec</goal>
                         </goals>

--- a/oag/pom.xml
+++ b/oag/pom.xml
@@ -278,7 +278,61 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-
+            <!-- To generate a self-signed certificate. -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <executable>keytool</executable>
+                    <workingDirectory>.</workingDirectory>
+                    <arguments>
+                        <argument>-genkeypair</argument>
+                        <argument>-alias</argument>
+                        <argument>tls</argument>
+                        <argument>-keyalg</argument>
+                        <argument>RSA</argument>
+                        <argument>-keystore</argument>
+                        <argument>keystore.pkcs12</argument>
+                        <argument>-storetype</argument>
+                        <argument>PKCS12</argument>
+                        <argument>-keysize</argument>
+                        <argument>2048</argument>
+                        <argument>-keypass</argument>
+                        <argument>password</argument>
+                        <argument>-storepass</argument>
+                        <argument>password</argument>
+                        <argument>-validity</argument>
+                        <argument>720</argument>
+                        <argument>-dname</argument>
+                        <argument>"cn=demo, ou=oag, o=owasp, c=com"</argument>
+                    </arguments>
+                </configuration>
+            </plugin>
+            <!-- To remove the generated self-signed certificate. -->
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>3.4.0</version>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>.</directory>
+                            <includes>
+                                <include>keystore.pkcs12</include>
+                            </includes>
+                            <followSymlinks>false</followSymlinks>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/oag/sample-config.yaml
+++ b/oag/sample-config.yaml
@@ -1,4 +1,4 @@
-hostUri: http://localhost:8080
+hostUri: https://localhost:8080
 
 routes:
   httpbin:

--- a/oag/src/main/resources/application.yaml
+++ b/oag/src/main/resources/application.yaml
@@ -4,6 +4,12 @@ oag:
 
 server:
   port: 8080
+  ssl:
+    key-store-type: PKCS12
+    key-store: keystore.pkcs12
+    key-store-password: password
+    key-alias: tls
+    enabled-protocols: TLSv1.3
 spring:
   application:
     name: OWASP Application Gateway

--- a/oag/src/main/resources/default-config.yaml
+++ b/oag/src/main/resources/default-config.yaml
@@ -1,4 +1,4 @@
-hostUri: http://localhost:8080
+hostUri: https://localhost:8080
 
 trustedRedirectHosts: [ ]
 

--- a/oag/src/test/java/org/owasp/oag/config/FileConfigLoaderTest.java
+++ b/oag/src/test/java/org/owasp/oag/config/FileConfigLoaderTest.java
@@ -16,7 +16,7 @@ class FileConfigLoaderTest {
     /**
      * Test if the FileConfigLoader correctly request a configuration file via HTTPS if
      * the configuration path is a https url
-     * @throws Exception
+     * @throws Exception in case of error.
      */
     @Test
     void loadConfigFileViaHttps() throws Exception {
@@ -46,7 +46,7 @@ class FileConfigLoaderTest {
 
     /**
      * Tests if the FileConfigLoader correctly loads a configuration file from disk
-     * @throws Exception
+     * @throws Exception in case of error.
      */
     @Test
     void loadConfigFromFile() throws Exception{
@@ -59,7 +59,7 @@ class FileConfigLoaderTest {
 
         // Assert
         assertNotNull(mainConfig);
-        assertEquals("http://localhost:8080", mainConfig.getHostUri());
+        assertEquals("https://localhost:8080", mainConfig.getHostUri());
 
     }
 }

--- a/oag/src/test/java/org/owasp/oag/integration/testInfrastructure/WiremockTest.java
+++ b/oag/src/test/java/org/owasp/oag/integration/testInfrastructure/WiremockTest.java
@@ -18,8 +18,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import java.net.URI;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Base class for all tests that use the gateway functionality.
@@ -28,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @AutoConfigureWireMock(port = 0)
 public abstract class WiremockTest {
 
-    public static String TEST_SERVER_URI = "http://localhost:7777";
     public static String TEST_1_ENDPOINT = "/foo";
     public static String TEST_1_RESPONSE = "foo}";
     public static String TEST_2_ENDPOINT = "/bar";
@@ -95,8 +93,8 @@ public abstract class WiremockTest {
                     .expectStatus().isFound().returnResult(String.class);
 
             var redirectUriString = loginResult.getResponseHeaders().getFirst("Location");
+            assertNotNull(redirectUriString);
             URI redirectUri = new URI(redirectUriString);
-
 
             AuthenticationRequest oidcRequest = AuthenticationRequest.parse(redirectUri);
             LoginProvider provider = config.getLoginProviders().get("local");
@@ -105,7 +103,7 @@ public abstract class WiremockTest {
             assertEquals(provider.getWith().get("clientId"), oidcRequest.getClientID().toString());
 
             var loginStateCookie = loginResult.getResponseCookies().getFirst(LoginStateCookie.NAME);
-
+            assertNotNull(loginStateCookie);
             // ACT 2: Call the callback url
             // Arrange
             String authorizationResponse = String.format("?state=%s&code=%s", oidcRequest.getState().getValue(), "authCode");


### PR DESCRIPTION
OAG uses self-signed certificate and TLS by default.
Documentation updated to describe how a custom "real" certificate can be configured (https://github.com/The-OAG-Development-Project/Application-Gateway/wiki/TLS-configuration-in-OAG).
closes #150 